### PR TITLE
switch to `element` from `selector`

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,25 +7,6 @@ const emitter = new EventEmitter();
 let scriptLoaded = false;
 let scriptLoading = false;
 
-//http://stackoverflow.com/questions/4588119/get-elements-css-selector-when-it-doesnt-have-an-id
-function fullPath(el){
-  var names = [];
-  while (el.parentNode){
-    if (el.id){
-      names.unshift('#'+el.id);
-      break;
-    }else{
-      if (el==el.ownerDocument.documentElement) names.unshift(el.tagName);
-      else{
-        for (var c=1,e=el;e.previousElementSibling;e=e.previousElementSibling,c++);
-        names.unshift(el.tagName+":nth-child("+c+")");
-      }
-      el=el.parentNode;
-    }
-  }
-  return names.join(" > ");
-}
-
 
 class Apparatus extends React.Component {
 
@@ -85,14 +66,14 @@ class Apparatus extends React.Component {
     console.log('initializing viewer')
     console.log({
       url: this.props._url,
-      selector: fullPath(this._ref),
+      element: this._ref,
       regionOfInterest: this.props._regionOfInterest,
       onRender: this.handleViewerRender
     })
     this.setState({
       viewer: new ApparatusViewer({
         url: this.props._url,
-        selector: fullPath(this._ref),
+        element: this._ref,
         regionOfInterest: this.props._regionOfInterest,
         onRender: this.handleViewerRender
       })


### PR DESCRIPTION
This isn't thoroughly tested, but it seems to basically work. (Was there some issue giving `ApparatusViewer` an element directly?)